### PR TITLE
[#Feature] Implemented Delete Meal Option Endpoint

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -29,3 +29,26 @@ exports.updateMealOption = (req, res) => {
     message: 'Meal Option Updated'
   });
 };
+
+exports.deleteMealOption = async (req, res) => {
+  const { id } = req.params;
+  let response;
+  if (Meal.deleteById(id)) {
+    response = {
+      code: 200,
+      body: {
+        status: 'success',
+        message: 'Meal Option Deleted'
+      }
+    };
+  } else {
+    response = {
+      code: 500,
+      body: {
+        status: 'error',
+        message: 'Failed to delete Mel Option'
+      }
+    };
+  }
+  return res.status(response.code).json(response.body);
+};

--- a/data/meals.json
+++ b/data/meals.json
@@ -1,1 +1,8 @@
-[{"id":"1","name":"Jollof Rice","price":1000,"imageUrl":"https://whereismyspoon.co/wp-content/uploads/2018/07/jollof-rice-3.jpg"},{"id":2,"name":"Fried Rice","price":1000,"imageUrl":"https://whereismyspoon.co/wp-content/uploads/2018/07/jollof-rice-3.jpg"}]
+[
+  {
+    "id": "1",
+    "name": "Jollof Rice",
+    "price": 1000,
+    "imageUrl": "https://whereismyspoon.co/wp-content/uploads/2018/07/jollof-rice-3.jpg"
+  }
+]

--- a/models/meals.js
+++ b/models/meals.js
@@ -58,6 +58,16 @@ class Meal {
     const meals = await getMealsFromFile();
     return meals;
   }
+
+  static async deleteById(id) {
+    const meals = await getMealsFromFile();
+    const existingMealIndex = meals.findIndex(meal => Number(meal.id) === Number(id));
+    meals.splice(existingMealIndex, 1);
+    fs.writeFile(p, JSON.stringify(meals), err => {
+      if (err) console.log(err);
+    });
+    return true;
+  }
 }
 
 export default Meal;

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -9,4 +9,6 @@ router.post('/meals/', adminController.addMealOption);
 
 router.put('/meals/:id', adminController.updateMealOption);
 
+router.delete('/meals/:id', adminController.deleteMealOption);
+
 module.exports = router;


### PR DESCRIPTION
**What Does This PR do?**
- Implement Delete Meal Options Endpoint

**Description of Task to be completed?**
- Create Delete Meal Options Route
- Create Delete Meal Options Controller Method

**How should this be manually tested?**
- Pull `ft-delete-meal-option` and run `npm install`
- Run `npm start`
- Make a **DELETE** request to `http://localhost:4000/api/v1/meals/:id` , where :id is the ID of the meal option in the json string

**Screenshots**
![delete-meal-option](https://user-images.githubusercontent.com/28724848/52500683-e4a0fa80-2bde-11e9-9331-741d9bd2e65a.JPG)