### PR TITLE
[#Feature] Caterer Signup Endpoint

### DIFF
--- a/api/controllers/auth.js
+++ b/api/controllers/auth.js
@@ -23,6 +23,31 @@ class AuthController {
       });
     }
   }
+
+  static async verifyAdminToken(req, res, next) {
+    const token = req.headers.authorization;
+    if (!token) {
+      return res.status(401).json({
+        status: 'error',
+        message: 'No Token Provided'
+      });
+    }
+    const jwtToken = token.split(' ')[1];
+    try {
+      const decoded = await jwt.verify(jwtToken, secret);
+      if (!decoded.isCaterer) {
+        throw new Error('Unauthorized');
+      }
+      req.caterer = decoded.caterer;
+      next();
+      return true;
+    } catch (err) {
+      return res.status(401).json({
+        status: 'error',
+        message: 'Unauthorized'
+      });
+    }
+  }
 }
 
 export default AuthController;

--- a/api/controllers/caterer.js
+++ b/api/controllers/caterer.js
@@ -1,0 +1,36 @@
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import Caterer from '../models/caterer';
+import secret from '../util/jwt_secret';
+
+class CatererController {
+  static async registerCaterer(req, res) {
+    try {
+      const { name, email, phone, password } = req.body;
+      const hash = await bcrypt.hash(password, 10);
+      const caterer = await Caterer.create({ name, email, phone, password: hash });
+      const safeCaterer = {
+        id: caterer.id,
+        name: caterer.name,
+        email: caterer.email,
+        phone: caterer.phone
+      };
+      const jwtToken = jwt.sign({ caterer: safeCaterer, isCaterer: true }, secret, {
+        expiresIn: 86400
+      });
+      return res.status(201).json({
+        status: 'success',
+        message: 'Caterer Registered',
+        token: `Bearer ${jwtToken}`,
+        caterer: safeCaterer
+      });
+    } catch (err) {
+      return res.status(500).json({
+        status: 'error',
+        message: err.message
+      });
+    }
+  }
+}
+
+export default CatererController;

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -15,7 +15,7 @@ class UserController {
         email: user.email,
         phone: user.phone
       };
-      const jwtToken = jwt.sign({ safeUser }, secret, {
+      const jwtToken = jwt.sign({ user: safeUser }, secret, {
         expiresIn: 86400
       });
       return res.status(201).json({

--- a/api/middleware/caterer.js
+++ b/api/middleware/caterer.js
@@ -1,0 +1,6 @@
+import Joi from 'joi';
+import UserMiddleware from './user';
+
+class CatererMiddleware extends UserMiddleware {}
+
+export default CatererMiddleware;

--- a/api/middleware/user.js
+++ b/api/middleware/user.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 class UserMiddleware {
-  static async validateUserRegister(req, res, next) {
+  static async validateRegister(req, res, next) {
     try {
       const schema = {
         name: Joi.string().required(),
@@ -27,7 +27,7 @@ class UserMiddleware {
     }
   }
 
-  static async validateUserLogin(req, res, next) {
+  static async validateLogin(req, res, next) {
     try {
       const schema = {
         email: Joi.string()

--- a/api/models/caterer.js
+++ b/api/models/caterer.js
@@ -18,7 +18,7 @@ const Caterer = sequelize.define('caterer', {
     unique: true
   },
   phone: {
-    type: Sequelize.INTEGER,
+    type: Sequelize.STRING,
     allowNull: false
   },
   password: {

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,26 +1,35 @@
 import express from 'express';
 import trimRequest from 'trim-request';
 import UserMiddleware from './middleware/user';
+import CatererMiddleware from './middleware/caterer';
 import AuthController from './controllers/auth';
 import MealController from './controllers/meals';
 import MenuController from './controllers/menu';
 import OrderController from './controllers/orders';
 import UserController from './controllers/user';
+import CatererController from './controllers/caterer';
 
 const router = express.Router();
 
 router.post(
   '/auth/signup',
   trimRequest.body,
-  UserMiddleware.validateUserRegister,
+  UserMiddleware.validateRegister,
   UserController.registerUser
 );
 
 router.post(
   '/auth/login',
   trimRequest.body,
-  UserMiddleware.validateUserLogin,
+  UserMiddleware.validateLogin,
   UserController.loginUser
+);
+
+router.post(
+  '/auth/caterer/signup',
+  trimRequest.body,
+  CatererMiddleware.validateRegister,
+  CatererController.registerCaterer
 );
 
 router.get('/meals/', MealController.getMealOptions);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "api/index.js",
   "scripts": {
     "start": "nodemon --exec babel-node api/index.js",
-    "test": "nyc mocha -r esm -t 0 --exit",
+    "test": "nyc mocha -r esm --exit",
     "generate-lcov": "nyc report --reporter=text-lcov > lcov.info",
     "coveralls-coverage": "coveralls < lcov.info",
     "codeclimate-coverage": "codeclimate-test-reporter < lcov.info",

--- a/test/caterer.test.js
+++ b/test/caterer.test.js
@@ -1,0 +1,163 @@
+import chai from 'chai';
+import chaiHTTP from 'chai-http';
+import app from '../api/index';
+import Caterer from '../api/models/caterer';
+
+const { assert, expect, use } = chai;
+
+use(chaiHTTP);
+
+const API_PREFIX = '/api/v1';
+
+before(done => {
+  app.on('dbConnected', () => {
+    done();
+  });
+});
+
+describe('Caterer Auth Endpoints', () => {
+  it('POST /auth/caterer/signup - Caterer SignUp Validation Test', done => {
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/auth/caterer/signup`)
+      .send({
+        name: 'Roger Test',
+        email: 'roger@test.com',
+        phone: '08028372825'
+      })
+      .then(async res => {
+        try {
+          expect(res).to.have.status(400);
+          assert.equal(res.body.status, 'error');
+          assert.equal(res.body.type, 'validation');
+          done();
+        } catch (err) {
+          console.log(err.message);
+        }
+      })
+      .catch(err => console.log('POST /auth/caterer/signup', err.message));
+  });
+  it('POST /auth/caterer/signup - Caterer Can Sign Up', done => {
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/auth/caterer/signup`)
+      .send({
+        name: 'Roger Test',
+        email: 'roger@test.com',
+        phone: '08028372825',
+        password: 'password'
+      })
+      .then(async res => {
+        try {
+          expect(res).to.have.status(201);
+          assert.equal(res.body.status, 'success');
+          done();
+        } catch (err) {
+          console.log(err.message);
+        }
+      })
+      .catch(err => console.log('POST /auth/caterer/signup', err.message));
+  });
+  it("POST /auth/caterer/signup - Caterer Can't signup again with the same email", done => {
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/auth/caterer/signup`)
+      .send({
+        name: 'Roger Test',
+        email: 'roger@test.com',
+        phone: '08028372825',
+        password: 'password'
+      })
+      .then(async res => {
+        try {
+          expect(res).to.have.status(500);
+          assert.equal(res.body.status, 'error');
+          const caterer = await Caterer.findOne({ where: { email: 'roger@test.com' } });
+          await caterer.destroy();
+          done();
+        } catch (err) {
+          console.log(err.message);
+        }
+      })
+      .catch(err => console.log('POST /auth/caterer/signup', err.message));
+  });
+  // it('POST /auth/login - User Login Validation Test(Required)', done => {
+  //   chai
+  //     .request(app)
+  //     .post(`${API_PREFIX}/auth/login`)
+  //     .send({
+  //       email: 'roger@test.com'
+  //     })
+  //     .then(async res => {
+  //       try {
+  //         expect(res).to.have.status(400);
+  //         assert.equal(res.body.status, 'error');
+  //         assert.equal(res.body.type, 'validation');
+  //         done();
+  //       } catch (err) {
+  //         console.log(err.message);
+  //       }
+  //     })
+  //     .catch(err => console.log('POST /auth/login', err.message));
+  // });
+  // it('POST /auth/login - User Login Validation Test(Email)', done => {
+  //   chai
+  //     .request(app)
+  //     .post(`${API_PREFIX}/auth/login`)
+  //     .send({
+  //       email: 'roger',
+  //       password: 'password'
+  //     })
+  //     .then(async res => {
+  //       try {
+  //         expect(res).to.have.status(400);
+  //         assert.equal(res.body.status, 'error');
+  //         assert.equal(res.body.type, 'validation');
+  //         done();
+  //       } catch (err) {
+  //         console.log(err.message);
+  //       }
+  //     })
+  //     .catch(err => console.log('POST /auth/login', err.message));
+  // });
+  // it('POST /auth/login - User Can Login', done => {
+  //   chai
+  //     .request(app)
+  //     .post(`${API_PREFIX}/auth/login`)
+  //     .send({
+  //       email: 'roger@test.com',
+  //       password: 'password'
+  //     })
+  //     .then(async res => {
+  //       try {
+  //         expect(res).to.have.status(200);
+  //         assert.equal(res.body.status, 'success');
+  //         done();
+  //       } catch (err) {
+  //         console.log(err.message);
+  //       }
+  //     })
+  //     .catch(err => console.log('POST /auth/login', err.message));
+  // });
+  // it("POST /auth/login - User Can't login with incorrect password", done => {
+  //   chai
+  //     .request(app)
+  //     .post(`${API_PREFIX}/auth/login`)
+  //     .send({
+  //       email: 'roger@test.com',
+  //       password: 'password111'
+  //     })
+  //     .then(async res => {
+  //       try {
+  //         expect(res).to.have.status(500);
+  //         assert.equal(res.body.status, 'error');
+  //         const user = await User.findOne({ where: { email: 'roger@test.com' } });
+  //         await user.destroy();
+  //         done();
+  //       } catch (err) {
+  //         console.log(err.message);
+  //       }
+  //     })
+  //     .catch(err => console.log('POST /auth/login', err.message));
+  // });
+});

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -9,12 +9,6 @@ use(chaiHTTP);
 
 const API_PREFIX = '/api/v1';
 
-before(done => {
-  app.on('dbConnected', () => {
-    done();
-  });
-});
-
 describe('User Auth Endpoints', () => {
   it('POST /auth/signup - User SignUp Validation Test(Required)', done => {
     chai


### PR DESCRIPTION
**What Does This PR do?**
- Implement Caterer Signup Endpoint
- Test Caterer Signup Endpoint

**Description of Task to be completed?**
- Implement Caterer Signup route
- Implement Caterer Signup Controller Method
- Test Endpoint For all Edgecases

**How should this be manually tested?**
- Pull `ft-user-can-login` and run `npm install`
- Create .env file with the following variables 
1. DB_NAME
2. DB_USER
3. DB_PASSWORD
4. DB_HOST 
- Run `npm test`

**Screenshots**
![ft-caterer-can-signup](https://user-images.githubusercontent.com/28724848/52754775-0396f680-2ffc-11e9-9569-ff0d830cf44d.JPG)
