### PR TITLE
[#Feature] Caterer Can Get All Orders

### DIFF
--- a/api/controllers/meals.js
+++ b/api/controllers/meals.js
@@ -45,7 +45,7 @@ class MealController {
 
   static async updateMealOption(req, res) {
     try {
-      const meal = await Meal.findById(req.params.id);
+      const meal = await Meal.findOne({ where: { id: req.params.id } });
       if (!meal) {
         throw new Error(`Meal With ID ${req.params.id} does not exist`);
       }

--- a/api/controllers/orders.js
+++ b/api/controllers/orders.js
@@ -12,28 +12,19 @@ class OrderController {
   }
 
   static async getOrders(req, res) {
-    let response;
     try {
-      const orders = await Order.fetchAll();
-      response = {
-        code: 200,
-        body: {
-          status: 'success',
-          message: 'Orders Retrieved',
-          data: orders
-        }
-      };
+      const orders = await Order.findAll({ where: { catererId: req.caterer.id } });
+      return res.status(200).json({
+        status: 'success',
+        message: 'Orders Retrieved',
+        data: orders
+      });
     } catch (err) {
-      response = {
-        code: 500,
-        body: {
-          status: 'error',
-          message: 'Failed to Retrive Orders',
-          error: err.message
-        }
-      };
+      return res.status(500).json({
+        status: 'error',
+        message: err.message
+      });
     }
-    return res.status(response.code).json(response.body);
   }
 
   static async modifyOrder(req, res) {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -35,7 +35,7 @@ class UserController {
   static async loginUser(req, res) {
     try {
       const { email, password } = req.body;
-      const user = await User.find({ where: { email } });
+      const user = await User.findOne({ where: { email } });
       if (!user) {
         throw new Error('User with that email does not exist');
       }

--- a/api/routes.js
+++ b/api/routes.js
@@ -70,7 +70,7 @@ router.post(
   MenuController.addMealToMenu
 );
 
-router.get('/orders', OrderController.getOrders);
+router.get('/orders', AuthController.verifyAdminToken, OrderController.getOrders);
 
 router.post('/orders', OrderController.orderMeal);
 

--- a/test/caterer.test.js
+++ b/test/caterer.test.js
@@ -155,8 +155,7 @@ describe('Caterer Login Endpoint Tests', () => {
         try {
           expect(res).to.have.status(500);
           assert.equal(res.body.status, 'error');
-          const caterer = await Caterer.findOne({ where: { email: 'roger@test.com' } });
-          await caterer.destroy();
+          await Caterer.destroy({ where: { email: 'roger@test.com' } });
           done();
         } catch (err) {
           console.log(err.message);

--- a/test/meals.test.js
+++ b/test/meals.test.js
@@ -54,8 +54,7 @@ describe('Caterer Get all Meals Endpoint Tests', () => {
           try {
             expect(res).to.have.status(401);
             assert.equal(res.body.status, 'error');
-            const authUser = await User.findOne({ where: { email: 'billy@newton.com' } });
-            await authUser.destroy();
+            await User.destroy({ where: { email: 'billy@newton.com' } });
             done();
           } catch (err) {
             console.log(err.message);
@@ -90,8 +89,7 @@ describe('Caterer Get all Meals Endpoint Tests', () => {
           try {
             expect(res).to.have.status(200);
             assert.equal(res.body.status, 'success');
-            const authCaterer = await Caterer.findOne({ where: { email: 'billy@newton.com' } });
-            await authCaterer.destroy();
+            await Caterer.destroy({ where: { email: 'billy@newton.com' } });
             done();
           } catch (err) {
             console.log(err.message);
@@ -294,8 +292,7 @@ describe('Caterer Modify Meal Endpoint Tests', () => {
             try {
               expect(res).to.have.status(401);
               assert.equal(res.body.status, 'error');
-              const authUser = await User.findOne({ where: { email: 'billy@newton.com' } });
-              await authUser.destroy();
+              await User.destroy({ where: { email: 'billy@newton.com' } });
               done();
             } catch (err) {
               console.log(err.message);
@@ -443,8 +440,7 @@ describe('Caterer Can Delete Endpoint Tests', () => {
             try {
               expect(res).to.have.status(401);
               assert.equal(res.body.status, 'error');
-              const authUser = await User.findOne({ where: { email: 'billy@newton.com' } });
-              await authUser.destroy();
+              await User.destroy({ where: { email: 'billy@newton.com' } });
               done();
             } catch (err) {
               console.log(err.message);
@@ -480,8 +476,7 @@ describe('Caterer Can Delete Endpoint Tests', () => {
             try {
               expect(res).to.have.status(200);
               assert.equal(res.body.status, 'success');
-              const authCaterer = await Caterer.findOne({ where: { email: 'billy@newton.com' } });
-              await authCaterer.destroy();
+              await Caterer.destroy({ where: { email: 'billy@newton.com' } });
               done();
             } catch (err) {
               console.log(err.message);

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -54,8 +54,7 @@ describe('User Get all Menus Endpoint Tests', () => {
           try {
             expect(res).to.have.status(200);
             assert.equal(res.body.status, 'success');
-            const authUser = await User.findOne({ where: { email: 'bastard@stark.com' } });
-            await authUser.destroy();
+            await User.destroy({ where: { email: 'bastard@stark.com' } });
             done();
           } catch (err) {
             console.log(err.message);

--- a/test/order.test.js
+++ b/test/order.test.js
@@ -1,0 +1,101 @@
+import chai from 'chai';
+import chaiHTTP from 'chai-http';
+import jwt from 'jsonwebtoken';
+import app from '../api/index';
+import secret from '../api/util/jwt_secret';
+import User from '../api/models/user';
+import Caterer from '../api/models/caterer';
+import Order from '../api/models/orders';
+
+const { assert, expect, use } = chai;
+
+use(chaiHTTP);
+
+const API_PREFIX = '/api/v1';
+
+describe('Caterer Get all Orders Endpoint Tests', () => {
+  it(`GET ${API_PREFIX}/orders - Fetch All Orders (Unauthorized)`, done => {
+    chai
+      .request(app)
+      .get(`${API_PREFIX}/meals/`)
+      .then(async res => {
+        try {
+          expect(res).to.have.status(401);
+          assert.equal(res.body.status, 'error');
+          done();
+        } catch (err) {
+          console.log(err.message);
+        }
+      })
+      .catch(err => console.log('GET /orders', err.message));
+  });
+  it(`GET ${API_PREFIX}/orders - Fetch All Orders - (Normal User Unauthorized)`, done => {
+    User.create({
+      name: 'Bruce Wayne',
+      email: 'bruce@batman.com',
+      phone: '07075748392',
+      password: 'waynemanor'
+    }).then(user => {
+      const { id, name, email, phone } = user;
+      const token = jwt.sign(
+        {
+          user: { id, name, email, phone }
+        },
+        secret,
+        {
+          expiresIn: 86400
+        }
+      );
+      chai
+        .request(app)
+        .get(`${API_PREFIX}/orders`)
+        .set('Authorization', `Bearer ${token}`)
+        .then(async res => {
+          try {
+            expect(res).to.have.status(401);
+            assert.equal(res.body.status, 'error');
+            await User.destroy({ where: { email: 'bruce@batman.com' } });
+            done();
+          } catch (err) {
+            console.log(err.message);
+          }
+        })
+        .catch(err => console.log('GET /orders', err.message));
+    });
+  });
+  it(`GET ${API_PREFIX}/orders - Fetch All Orders - (Caterer Authorized)`, done => {
+    Caterer.create({
+      name: 'Joffery Baratheon',
+      email: 'jof@sppiledbrat.com',
+      phone: '07075748391',
+      password: 'oursisthefury'
+    }).then(caterer => {
+      const { id, name, email, phone } = caterer;
+      const token = jwt.sign(
+        {
+          caterer: { id, name, email, phone },
+          isCaterer: true
+        },
+        secret,
+        {
+          expiresIn: 86400
+        }
+      );
+      chai
+        .request(app)
+        .get(`${API_PREFIX}/orders`)
+        .set('Authorization', `Bearer ${token}`)
+        .then(async res => {
+          try {
+            expect(res).to.have.status(200);
+            assert.equal(res.body.status, 'success');
+            await Caterer.destroy({ where: { email: 'jof@sppiledbrat.com' } });
+            done();
+          } catch (err) {
+            console.log(err.message);
+          }
+        })
+        .catch(err => console.log('GET /orders', err.message));
+    });
+  });
+});

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -188,8 +188,7 @@ describe('User Auth Login Endpoint Tests', () => {
         try {
           expect(res).to.have.status(500);
           assert.equal(res.body.status, 'error');
-          const user = await User.findOne({ where: { email: 'roger@test.com' } });
-          await user.destroy();
+          await User.destroy({ where: { email: 'roger@test.com' } });
           done();
         } catch (err) {
           console.log(err.message);


### PR DESCRIPTION
**What Does this PR do?**
- Implements Caterer can get all orders endpoint

**Description of tasks to be done?**
- Add Get Orders route
- Modify Get Orders controller method
- Protect Route to be accessed by only authenticated caterers

**How can this be tested?**
- Pull `ft-caterer-can-get-orders` branch 
- Run `npm install`
- Run `npm test`