### PR TITLE
[#Feature] Caterers Can Get thier menu endpoint

### DIFF
--- a/api/controllers/menu.js
+++ b/api/controllers/menu.js
@@ -26,6 +26,23 @@ class MenuController {
     }
   }
 
+  static async getSingleMenu(req, res) {
+    try {
+      const today = MenuController.generateDate();
+      const menu = await Menu.findOne({ where: { createdAt: today, catererId: req.caterer.id } });
+      return res.status(200).json({
+        status: 'success',
+        message: 'Caterer Menu Retrieved',
+        data: menu
+      });
+    } catch (err) {
+      return res.status(500).json({
+        status: 'error',
+        message: err.message
+      });
+    }
+  }
+
   static async addMealToMenu(req, res) {
     try {
       const { mealId, quantity } = req.body;

--- a/api/routes.js
+++ b/api/routes.js
@@ -63,6 +63,8 @@ router.delete('/meals/:id', AuthController.verifyAdminToken, MealController.dele
 
 router.get('/menu/', AuthController.verifyUserToken, MenuController.getMenus);
 
+router.get('/menu/caterer', AuthController.verifyAdminToken, MenuController.getSingleMenu);
+
 router.post(
   '/menu/',
   trimRequest.body,


### PR DESCRIPTION
**What Does this PR do?**
- Implements Caterer can get their menu endpoint

**Description of tasks to be done?**
- Add Caterer Get Menu route
- Create Get Single Menu by Caterer ID controller method
- Protect Route to be accessed by only authenticated caterers

**How can this be tested?**
- Pull `ft-caterer-can-get-their-menu` branch 
- Run `npm install`
- Run `npm test`